### PR TITLE
Use double quotes in docker-release JSON inputs

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -14,11 +14,11 @@ jobs:
     needs: versioning
     if: ${{ needs.versioning.outputs.next-version != '' }}
     with:
-      projects: "['.']"
+      projects: '["."]'
       version: ${{ needs.versioning.outputs.next-version }}
       docker-registry: "abc.docker-registry.gewis.nl"
       github-registry: 'true'
-      docker-paths: "['eou/pdf-compiler']"
+      docker-paths: '["eou/pdf-compiler"]'
     secrets:
       REGISTRY_USERNAME: ${{ secrets.SVC_GH_ABCEOU_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.SVC_GH_ABCEOU_PWD }}


### PR DESCRIPTION
The shared docker-release workflow feeds `projects` and `docker-paths` into JSON.parse() via a Node.js heredoc. Single-quoted array literals (['.']) are not valid JSON; replace with double-quoted equivalents (["."]) so the matrix generation step no longer throws a SyntaxError.
