### PR TITLE
Set up Dependabot auto-merge and action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,13 @@ updates:
           - major
           - minor
           - patch
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "JustSamuel"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,21 @@
+name: Dependabot Auto Approve and Merge
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependabot:
+    uses: GEWIS/actions/.github/workflows/dependabot-auto-merge.yml@v1
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      auto-approve: true
+      auto-merge: true
+      merge-method: 'squash'


### PR DESCRIPTION
Adds a Dependabot auto-merge workflow that calls the reusable `dependabot-auto-merge.yml@v1` from GEWIS/actions. For dependabot PRs targeting `main`, it auto-approves and turns on GitHub auto-merge (squash) so routine dependency bumps land once required checks pass, without waiting on a manual review.

Also adds a `github-actions` ecosystem to `dependabot.yml` (weekly, grouped into one PR) so the action pins in our workflows stay current. The existing gomod and npm/client entries are unchanged.